### PR TITLE
Use env-based API URL in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Environment variables:
 4) POSTGRES_PORT=5432
 5) LOCAL_PG_DATA=./postgres_data
 6) PGDATA=/var/lib/postgresql/data/pgdata
+7) VITE_API_URL=http://localhost:8000
 
 
 Main python backend requirements located at file /backend/requirements.txt

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/components/AllScripts.jsx
+++ b/frontend/src/components/AllScripts.jsx
@@ -25,7 +25,7 @@ export default function AllScripts() {
 
   // Загрузка таблицы
   useEffect(() => {
-    fetch("/api/scripts")
+    fetch(`${import.meta.env.VITE_API_URL}/api/scripts`)
       .then(res => res.json())
       .then(scripts =>
         setData(scripts.map(s => ({
@@ -49,7 +49,7 @@ export default function AllScripts() {
     }
 
     try {
-      const res = await fetch(`/api/scripts/${id}`, { method: "DELETE" });
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/scripts/${id}`, { method: "DELETE" });
       if (!res.ok) {
         const err = await res.json().catch(() => ({ detail: res.statusText }));
         throw new Error(err.detail || res.statusText);

--- a/frontend/src/components/Auth.jsx
+++ b/frontend/src/components/Auth.jsx
@@ -26,7 +26,7 @@ const Auth = () => {
     setIsLoading(true);
     console.log("handleAuth triggered:", { email, password });
     try {
-      const response = await fetch("/api/login", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),

--- a/frontend/src/components/Create.jsx
+++ b/frontend/src/components/Create.jsx
@@ -44,7 +44,7 @@ const Create = () => {
         console.log("Отправляемые данные:", requestData);
 
         try {
-            const response = await fetch("http://192.168.220.198/api/create_vm/", {
+            const response = await fetch(`${import.meta.env.VITE_API_URL}/api/create_vm/`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/frontend/src/components/EditScriptModal.jsx
+++ b/frontend/src/components/EditScriptModal.jsx
@@ -14,7 +14,7 @@ export default function EditScriptModal({ open, onClose, script, onSave }) {
     setLoading(true);
 
     // Подтягиваем весь массив, затем ищем нужный скрипт
-    fetch("/api/scripts")
+    fetch(`${import.meta.env.VITE_API_URL}/api/scripts`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -42,7 +42,7 @@ export default function EditScriptModal({ open, onClose, script, onSave }) {
 
   const handleSave = async () => {
     try {
-      const res = await fetch(`/api/scripts/${script.id}`, {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/scripts/${script.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description }),

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -12,7 +12,7 @@ const Home = () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:8000/vms/"); // Поменяйте URL на ваш
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/vms/`);
       if (!response.ok) {
         throw new Error(`Ошибка ${response.status}: ${response.statusText}`);
       }

--- a/frontend/src/components/LeftMenu.jsx
+++ b/frontend/src/components/LeftMenu.jsx
@@ -11,7 +11,7 @@ const LeftMenu = ({ isActive, isCollapsed, sidebarRef }) => {
   async function logout() {
     try {
       // Опционально: сначала делаем logout-запрос на бэкенд
-      const res = await fetch("/api/logout", {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/logout`, {
         method: "POST",
         headers: {
           Authorization: "Bearer " + sessionStorage.getItem("token"),

--- a/frontend/src/components/ProfileBtn.jsx
+++ b/frontend/src/components/ProfileBtn.jsx
@@ -11,7 +11,7 @@ export default function ProfileBtn() {
     const token = sessionStorage.getItem("token");
     if (!token) return;
 
-    fetch("/api/me", {
+    fetch(`${import.meta.env.VITE_API_URL}/api/me`, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/frontend/src/components/ProfilePage.jsx
+++ b/frontend/src/components/ProfilePage.jsx
@@ -17,7 +17,7 @@ export default function ProfilePage() {
     const token   = sessionStorage.getItem("token");
     const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-    fetch("/api/me", { headers })
+    fetch(`${import.meta.env.VITE_API_URL}/api/me`, { headers })
       .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
       .then(profile => {
         setMe(profile);

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -12,7 +12,7 @@ export function ProtectedRoute() {
       return;
     }
 
-    fetch("api/protected", {
+    fetch(`${import.meta.env.VITE_API_URL}/api/protected`, {
       headers: { Authorization: "Bearer " + token },
     })
       .then(res => res.ok ? setStatus("ok") : setStatus("fail"))

--- a/frontend/src/components/Registration.jsx
+++ b/frontend/src/components/Registration.jsx
@@ -36,7 +36,7 @@ const Registration = () => {
 
     setIsLoading(true);
     try {
-      const response = await fetch("/api/register", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/ScriptInfo.jsx
+++ b/frontend/src/components/ScriptInfo.jsx
@@ -12,7 +12,7 @@ const ScriptInfo = ({ open, onClose, script }) => {
       return;
     }
     setLoading(true);
-    fetch("/api/scripts")
+    fetch(`${import.meta.env.VITE_API_URL}/api/scripts`)
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();

--- a/frontend/src/components/Scripts.jsx
+++ b/frontend/src/components/Scripts.jsx
@@ -50,7 +50,7 @@ export default function ScriptsTable({osType, vmId}) {
   // --- Загрузка списка скриптов ---
   useEffect(() => {
     setLoading(true);
-    fetch('/api/scripts')
+    fetch(`${import.meta.env.VITE_API_URL}/api/scripts`)
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -114,7 +114,7 @@ export default function ScriptsTable({osType, vmId}) {
   const handleRunClick = async (item) => {
     setScriptForInstall(item);
     try {
-      const res = await fetch(`/api/scripts/${item._raw.id}/survey_vars`);
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/scripts/${item._raw.id}/survey_vars`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const defs = await res.json();
       setInstallModalVars(defs);
@@ -147,7 +147,7 @@ export default function ScriptsTable({osType, vmId}) {
     );
 
     try {
-      const createRes = await fetch('/api/run_playbook', {
+      const createRes = await fetch(`${import.meta.env.VITE_API_URL}/api/run_playbook`, {
         method:  'POST',
         headers: {'Content-Type': 'application/json'},
         body:    JSON.stringify({
@@ -170,7 +170,7 @@ export default function ScriptsTable({osType, vmId}) {
       const timer = setInterval(async () => {
         try {
           const statusRes = await fetch(
-            `/api/run_playbook/status?task_id=${task_id}`
+            `${import.meta.env.VITE_API_URL}/api/run_playbook/status?task_id=${task_id}`
           );
           if (!statusRes.ok) throw new Error(`HTTP ${statusRes.status}`);
           const {status, output} = await statusRes.json();

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -29,7 +29,7 @@ export default function Settings() {
         setIsLoading(true);
 
         try {
-            const res = await fetch("/api/scripts", {
+            const res = await fetch(`${import.meta.env.VITE_API_URL}/api/scripts`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ name, path, description, tag, app }),

--- a/frontend/src/components/Users.jsx
+++ b/frontend/src/components/Users.jsx
@@ -24,8 +24,8 @@ export default function Users() {
 
     // параллельно запрашиваем список пользователей и список ролей
     Promise.all([
-      fetch("/api/users", { headers }).then(r => r.ok ? r.json() : Promise.reject(r.statusText)),
-      fetch("/api/roles", { headers }).then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      fetch(`${import.meta.env.VITE_API_URL}/api/users`, { headers }).then(r => r.ok ? r.json() : Promise.reject(r.statusText)),
+      fetch(`${import.meta.env.VITE_API_URL}/api/roles`, { headers }).then(r => r.ok ? r.json() : Promise.reject(r.statusText))
     ])
       .then(([usersData, rolesData]) => {
         setUsers(usersData);
@@ -43,7 +43,7 @@ export default function Users() {
     const token   = sessionStorage.getItem("token");
     const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-    fetch(`/api/users/${userId}/role`, {
+    fetch(`${import.meta.env.VITE_API_URL}/api/users/${userId}/role`, {
       method: "PATCH",
       headers,
       body: JSON.stringify({ role: newRole }),

--- a/frontend/src/components/VMSettings.jsx
+++ b/frontend/src/components/VMSettings.jsx
@@ -38,7 +38,7 @@ const VMSettings = () => {
       setError(null);
 
       try {
-        const response = await fetch("http://localhost:8000/vms/"); // Укажите ваш URL
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/vms/`);
         if (!response.ok) {
           throw new Error(`Ошибка ${response.status}: ${response.statusText}`);
         }


### PR DESCRIPTION
## Summary
- add new `VITE_API_URL` variables for the frontend
- reference `VITE_API_URL` in fetch calls
- document API variable in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f9bf8b44832c8ae3604518a0f4a2