### PR TITLE
Fix semaphore env write permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
   semaphore:
     image: semaphoreui/semaphore:v2.13.15-powershell7.5.0
     entrypoint: ["/init.sh"]
+    user: root
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary
- allow semaphore container to run as root so it can rewrite `/tmp/.env`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843fe5f31fc832c961a68a2675e7171