### PR TITLE
Use relative API endpoints

### DIFF
--- a/frontend/src/components/Create.jsx
+++ b/frontend/src/components/Create.jsx
@@ -44,7 +44,7 @@ const Create = () => {
         console.log("Отправляемые данные:", requestData);
 
         try {
-            const response = await fetch("http://192.168.220.198/api/create_vm/", {
+            const response = await fetch("/api/create_vm/", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -12,7 +12,7 @@ const Home = () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:8000/vms/"); // Поменяйте URL на ваш
+      const response = await fetch("/vms/");
       if (!response.ok) {
         throw new Error(`Ошибка ${response.status}: ${response.statusText}`);
       }

--- a/frontend/src/components/VMSettings.jsx
+++ b/frontend/src/components/VMSettings.jsx
@@ -38,7 +38,7 @@ const VMSettings = () => {
       setError(null);
 
       try {
-        const response = await fetch("http://localhost:8000/vms/"); // Укажите ваш URL
+        const response = await fetch("/vms/");
         if (!response.ok) {
           throw new Error(`Ошибка ${response.status}: ${response.statusText}`);
         }


### PR DESCRIPTION
## Summary
- update Create VM, Home, and VMSettings components to use relative URLs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ba834ea88832cb4b76c3bcf560f13