### PR TITLE
Improve README with service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,89 @@
-# React + Vite
+# Cyberpoligon Services
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project bundles a small infrastructure consisting of a FastAPI backend, a React frontend and a PostgreSQL database.  The containers are orchestrated with **docker-compose**.
 
-Currently, two official plugins are available:
+## Services
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+### db
+* `postgres:15-alpine` image
+* initialized by `postgres-init/postgres-init.sh`
+* listens on host port **5433**
 
+### backend
+* located in `backend/`
+* runs Alembic migrations and seeds initial data on start via `backend/entrypoint.sh`
+* exposed on port **8000**
 
-Start project: 
-1) Change the working directory to a folder containing docker-compose.yml file
-2) Run docker-compose up -d --build
+### worker
+* same image and code base as the backend for background tasks
+* exposed on port **8100**
 
+### frontend
+* React application in `frontend/`
+* built with Vite and served on port **5173**
 
-Environment variables:
+### nginx
+* `nginx:stable-alpine` acting as a reverse proxy for the frontend and backend
 
-1) POSTGRES_USER=admin
-2) POSTGRES_PASSWORD=securepass123
-3) POSTGRES_DB=appdb
-4) POSTGRES_PORT=5432
-5) LOCAL_PG_DATA=./postgres_data
-6) PGDATA=/var/lib/postgresql/data/pgdata
+### semaphore
+* [Semaphore](https://github.com/ansible-semaphore/semaphore) for running Ansible playbooks
+* stores data in the same PostgreSQL instance
+* accessible on port **3000**
 
+## Environment variables
 
-Main python backend requirements located at file /backend/requirements.txt
+Copy `env.example` to `.env` and adjust values as required.  Important variables include:
 
+```
+DB_HOST=db
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=qweasdZXC123
+DB_NAME=Npis
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=qweasdZXC123
+POSTGRES_MULTIPLE_DATABASES=Npis,semaphore
+SEMAPHORE_DB_DIALECT=postgres
+SEMAPHORE_DB_NAME=semaphore
+SEMAPHORE_DB_USER=postgres
+SEMAPHORE_DB_PASS=qweasdZXC123
+SEMAPHORE_DB_PORT=5432
+SEMAPHORE_ADMIN=admin
+SEMAPHORE_ADMIN_PASSWORD=changeme
+SEMAPHORE_ADMIN_NAME=Admin
+SEMAPHORE_ADMIN_EMAIL=admin@localhost
+```
+
+## Using docker-compose
+
+Start all services from the project root:
+
+```bash
+docker-compose up -d --build
+```
+
+Stop and remove containers:
+
+```bash
+docker-compose down
+```
+
+## Running migrations
+
+Migrations are executed automatically when the backend container starts.  To run them manually:
+
+```bash
+docker-compose exec backend alembic upgrade head
+```
+
+## Running tests
+
+Ansible playbooks in `ansible/tests/` act as basic tests.  Execute them from inside the backend container, e.g.:
+
+```bash
+docker-compose exec backend ansible-playbook ansible/tests/test_ping.yml -i ansible/tests/inventory
+```
+
+There are currently no automated Python or frontend test suites.
+
+Main Python requirements are listed in `backend/requirements.txt`.


### PR DESCRIPTION
## Summary
- explain backend, frontend, and database services
- document environment variables
- show how to use docker-compose
- add notes about running migrations and basic tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install`
- `npm run lint` *(fails: Cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684baab9fa40832cb4243476d74856ae